### PR TITLE
Enable text selection as description in bookmarklet

### DIFF
--- a/app/Helper/LinkAce.php
+++ b/app/Helper/LinkAce.php
@@ -15,8 +15,10 @@ class LinkAce
     public static function generateBookmarkletCode(): string
     {
         $bmCode = 'javascript:javascript:(function(){var%20url%20=%20location.href;' .
+            "var%20description=document.getSelection()||'';" .
             "var%20title%20=%20document.title%20||%20url;window.open('##URL##?u='%20+%20encodeURIComponent(url)" .
-            "+'&t='%20+%20encodeURIComponent(title),'_blank','menubar=no,height=720,width=600,toolbar=no," .
+            "+'&t='%20+%20encodeURIComponent(title)+'&d='+encodeURIComponent(description)," .
+            "'_blank','menubar=no,height=720,width=600,toolbar=no," .
             "scrollbars=yes,status=no,dialog=1');})();";
 
         $bmCode = str_replace('##URL##', route('bookmarklet-add'), $bmCode);

--- a/app/Http/Controllers/App/BookmarkletController.php
+++ b/app/Http/Controllers/App/BookmarkletController.php
@@ -20,12 +20,14 @@ class BookmarkletController extends Controller
     {
         $newUrl = $request->input('u');
         $newTitle = $request->input('t');
+        $newDescription = $request->input('d');
 
         // Redirect to the login if the user is not logged in
         if (!auth()->check()) {
             // Save details for the link in the session
             session(['bookmarklet.new_url' => $newUrl]);
             session(['bookmarklet.new_title' => $newTitle]);
+            session(['bookmarklet.new_description' => $newDescription]);
             session(['bookmarklet.login_redirect' => true]);
 
             return redirect()->route('bookmarklet-login');
@@ -35,6 +37,7 @@ class BookmarkletController extends Controller
             // Receive the link details from the session after the user logged in
             $newUrl = session()->pull('bookmarklet.new_url');
             $newTitle = session()->pull('bookmarklet.new_title');
+            $newDescription = session()->pull('bookmarklet.new_description');
         }
 
         session(['bookmarklet.create' => true]);
@@ -42,6 +45,7 @@ class BookmarkletController extends Controller
         return view('actions.bookmarklet.create', [
             'bookmark_url' => $newUrl,
             'bookmark_title' => $newTitle,
+            'bookmark_description' => $newDescription,
         ]);
     }
 

--- a/resources/views/models/links/partials/create-form.blade.php
+++ b/resources/views/models/links/partials/create-form.blade.php
@@ -44,7 +44,7 @@
                     <div class="form-group">
                         <label for="description">@lang('link.description')</label>
                         <textarea name="description" id="description" rows="4" class="form-control"
-                            >{{ old('description') }}</textarea>
+                            >{{ old('description') ?: $bookmark_description ?? '' }}</textarea>
 
                         @if ($errors->has('description'))
                             <p class="invalid-feedback" role="alert">


### PR DESCRIPTION
Optional text selection in the browser will be prefilled for the description field. Existing bookmarklets should be re-generated from the settings page.

That's my first PR for a laravel project and I'm not yet well versed with its test structure. Do I need to supply a test case for that?