### PR TITLE
Links and formatting used in RSS/Atom feeds

### DIFF
--- a/resources/views/app/feed/links.blade.php
+++ b/resources/views/app/feed/links.blade.php
@@ -1,19 +1,20 @@
 <?= '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ $meta['title'] }}</title>
-    <link href="{{ $meta['link'] }}"/>
+    <link rel="self" type="application/atom+xml" href="{{ $meta['link'] }}"/>
     <updated>{{ $meta['updated'] }}</updated>
     <id>{{ $meta['id'] }}</id>
     @foreach($links as $link)
         <entry>
-            <id>{{ $link->url }}</id>
-            <title><![CDATA[{{ $link->title }}]]></title>
-            <link rel="alternate" href="{{ route('links.show', ['link'=> $link]) }}" />
+            <id>{{ route('links.show', ['link'=> $link]) }}</id>
+            <title type="text"><![CDATA[{{ strip_tags($link->title) }}]]></title>
+            <link rel="alternate" href="{{ $link->url }}" />
+            <link rel="via" type="application/atom+xml" href="{{ route('links.show', ['link'=> $link]) }}"/>
             <author>
                 <name> <![CDATA[{{ $link->user->name }}]]></name>
             </author>
-            <summary type="html">
-                <![CDATA[{!! $link->markdownDescription !!}]]>
+            <summary type="text">
+                <![CDATA[{!! strip_tags($link->description) !!}]]>
             </summary>
             <updated>{{ $link->updated_at->toRfc3339String() }}</updated>
         </entry>


### PR DESCRIPTION
Hi

Thank you for releasing and maintaingin LinkAce, it is very useful!

This pull request solves the issue raised in #272, and take aim to adhere to [RFC4237](https://datatracker.ietf.org/doc/html/rfc4287). Furthermore, it resolves an issue in my test data where the _summary_ failed to populate with the link-description from LinkAce, and a few instances where _title_ was rendered with html escape characters in my rss reader.

The proposed changes have been validated using [W3C validation service](https://validator.w3.org/feed/), with my own dataset.

In essence the pull request consists of three changes:
1: The atom RFC requires the ID tag values to be universally unique. The current solution could potentially overlap between LinkAce instances for popular articles/urls. By changing the ID tag value to be the LinkAce article URL, it becomes a construct from individual linkace hostnames and article ID which should be globally unique as long as domain names for the instances does not change to often.

2: Change each entry block _link_ tags of ref type "alternate" to point to the original referred article. This solves #272 (which happens to align with my usage requirement as well). In order to retain the ability to directly access linkace web interface, this url is retained in a _link_ tag with the rel attribute set to "via". From the RFC the rel="via" is meant to be used for references to the entry itself.

3: Change in the entry block for _summary_ and _title_ tags. This change was necessary for linkace to show the article description in my dataset, and for all titles to render correctly in my rss reader. In this change request the link description variable is used, and since I'm unsure of all potential content I chose to strip it from tags and show it as plain text. I also explicitly set type to "text" for it to be processed correctly by rss readers. By using a text representation an RSS reader should be able to format the content at it sees best fitting for it's own user interface.

best regards,
Ole Kristoffer
