### PR TITLE
Fix typo in DE_de/trash.php

### DIFF
--- a/resources/lang/de_DE/trash.php
+++ b/resources/lang/de_DE/trash.php
@@ -4,7 +4,7 @@ return [
 
     'trash' => 'Papierkorb',
 
-    'deleted_links' => 'Löschte Links',
+    'deleted_links' => 'Gelöschte Links',
     'deleted_lists' => 'Gelöschte Listen',
     'deleted_tags' => 'Gelöschte Tags',
     'deleted_notes' => 'Gelöschte Notizen',


### PR DESCRIPTION
This fixes #414 - typo "Löschte Links" to "Gelöschte Links" in line 7 of resources/lang/de_DE/trash.php
 