### PR TITLE
Don't show "no results" when no search was performed

### DIFF
--- a/app/Http/Controllers/App/SearchController.php
+++ b/app/Http/Controllers/App/SearchController.php
@@ -32,6 +32,7 @@ class SearchController extends Controller
                 'only_lists' => '',
                 'only_tags' => '',
                 'order_by' => $this->orderByOptions[0],
+                'performed_search' => false,
             ]);
     }
 
@@ -60,6 +61,7 @@ class SearchController extends Controller
                 'empty_tags' => $this->emptyTags,
                 'empty_lists' => $this->emptyLists,
                 'order_by' => $this->searchOrderBy,
+                'performed_search' => true,
             ]);
     }
 }

--- a/resources/views/app/search/search.blade.php
+++ b/resources/views/app/search/search.blade.php
@@ -132,9 +132,11 @@
         <div class="card-table mt-4">
 
             @if($results->isEmpty())
-                <div class="alert alert-info m-3">
-                    @lang('search.no_results')
-                </div>
+                @if($query_settings['performed_search'])
+                    <div class="alert alert-info m-3">
+                        @lang('search.no_results')
+                    </div>
+                @endif
             @else
                 @include('app.search.partials.table', ['results' => $results])
             @endif


### PR DESCRIPTION
Particularly since the 'no results' alert is rather bright, not made for a dark theme. (Most alerts are overbright areas, but I am bad at color design so cannot really suggest better options.)