### PR TITLE
Don't show guest settings when guest mode is disabled

### DIFF
--- a/app/Http/Controllers/App/DashboardController.php
+++ b/app/Http/Controllers/App/DashboardController.php
@@ -44,7 +44,7 @@ class DashboardController extends Controller
             ->count();
 
         $totalNotes = Note::byUser()
-            ->count();            
+            ->count();
 
         $totalTags = Tag::byUser()
             ->count();

--- a/resources/views/app/settings/system.blade.php
+++ b/resources/views/app/settings/system.blade.php
@@ -8,6 +8,8 @@
 
     @include('app.settings.partials.system.general-settings')
 
-    @include('app.settings.partials.system.guest-settings')
+    @if(systemsettings('system_guest_access'))
+        @include('app.settings.partials.system.guest-settings')
+    @endif
 
 @endsection


### PR DESCRIPTION
Not sure if you agree with this change (I can also see reasons against it) so feel free to reject

Rationale: I was hunting for the button to enable guest mode, couldn't find it in the guest settings. Maybe the better solution is to move that setting to that section, but it also seems kind of odd to show settings for a mode that is entirely disabled in the first place. This pull request just hides the section when it's not enabled :)