### PR TITLE
Add support for Podman

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,13 @@ starting to code.
 
 ### Minimum Requirements
 
-* [Docker](https://www.docker.com/products/docker-desktop) _or_ PHP 7.4
+* [Docker](https://www.docker.com/products/docker-desktop)/[Podman](https://podman.io/docs/installation) _or_ a [currently-supported PHP version](https://www.php.net/supported-versions.php)
+  * For Podman, you also need to `apt`, `dnf`, or otherwise install [`podman-compose`](https://github.com/containers/podman-compose)
 * [Node](https://nodejs.org/en/) (16 LTS)
 
 ### 1. Basic Setup
 
-The following steps assume that you are using Docker for development, which I highly encourage. If you use other ways to work with PHP projects you must adapt the commands to your system. Clone the repository to your machine and run the following commands to start the Docker container system:
+The following steps assume that you are using Docker or Podman for development, which I highly encourage. If you use other ways to work with PHP projects you must adapt the commands to your system. If you want to use Podman, simply replace the word `docker` with `podman` in each command. Clone the repository to your machine and run the following commands to start the Docker container system:
 
 ```bash
 cp .env.docker .env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,15 @@ The following steps assume that you are using Docker or Podman for development, 
 
 ```bash
 cp .env.docker .env
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 Now, install all dependencies from inside the PHP container:
 
 ```bash
-docker exec -it linkace-php composer install
+docker compose exec -it php composer install
 
-docker exec -it linkace-php php artisan key:generate
+docker compose exec -it php php artisan key:generate
 ```
 
 Last step: compile all assets. Node 16 LTS is the minimum version required and recommended to use. You may use either NPM or Yarn for installing the asset dependencies.
@@ -58,7 +58,7 @@ npm run dev
 I recommend using the Artisan command line tool in the PHP container only, to make sure that the same environment is  used. To do so, use the following example command:
 
 ```bash
-docker exec -it linkace-php php artisan migrate
+docker compose exec -it php php artisan migrate
 ```
 
 #### 3. Registering a new user
@@ -66,7 +66,7 @@ docker exec -it linkace-php php artisan migrate
 Currently, you can do this by using the command line:
 
 ```bash
-docker exec -it linkace-php php artisan registeruser [user name] [user email]
+docker compose exec -it php php artisan registeruser [user name] [user email]
 ```
 
 
@@ -75,8 +75,8 @@ docker exec -it linkace-php php artisan registeruser [user name] [user email]
 You can run existing tests with the following command:
 
 ```bash
-docker exec -it linkace-php composer run lint
-docker exec -it linkace-php composer run test
+docker compose exec -it php composer run lint
+docker compose exec -it php composer run test
 ```
 
 

--- a/docker-compose.production-simple.yml
+++ b/docker-compose.production-simple.yml
@@ -4,7 +4,7 @@ services:
 
   # --- MariaDB
   db:
-    image: mariadb:11.2
+    image: docker.io/library/mariadb:11.2
     restart: unless-stopped
     command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     environment:
@@ -17,7 +17,7 @@ services:
 
   # --- LinkAce Image with PHP and nginx
   app:
-    image: linkace/linkace:simple
+    image: docker.io/library/linkace/linkace:simple
     restart: unless-stopped
     depends_on:
       - db

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -4,7 +4,7 @@ services:
 
   # --- MariaDB
   db:
-    image: mariadb:11.2
+    image: docker.io/library/mariadb:11.2
     restart: unless-stopped
     command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     environment:
@@ -17,7 +17,7 @@ services:
 
   # --- LinkAce Image with PHP
   app:
-    image: linkace/linkace:latest
+    image: docker.io/library/linkace/linkace:latest
     restart: unless-stopped
     depends_on:
       - db
@@ -29,7 +29,7 @@ services:
 
   # --- nginx
   nginx:
-    image: bitnami/nginx:1.24
+    image: docker.io/bitnami/nginx:1.24
     restart: unless-stopped
     ports:
       - "0.0.0.0:80:8080"
@@ -45,7 +45,7 @@ services:
 
   # --- Redis
   redis:
-    image: bitnami/redis:7.2
+    image: docker.io/bitnami/redis:7.2
     restart: unless-stopped
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
   # --- MariaDB
   db:
-    image: mariadb:11.2
+    image: docker.io/library/mariadb:11.2
     command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     environment:
       - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
@@ -18,7 +18,7 @@ services:
       - linkace-db:/var/lib/mysql
 
   pg-db:
-    image: postgres:14
+    image: docker.io/library/postgres:14
     environment:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_USER=${DB_USERNAME}
@@ -30,6 +30,7 @@ services:
 
   # --- PHP
   php:
+    container_name: linkace-php
     build:
       context: .
       dockerfile: ./resources/docker/dockerfiles/development.Dockerfile
@@ -41,7 +42,7 @@ services:
 
   # --- nginx
   nginx:
-    image: bitnami/nginx:1.25
+    image: docker.io/bitnami/nginx:1.25
     ports:
       - "80:8080"
     depends_on:
@@ -52,7 +53,7 @@ services:
 
   # --- Redis
   redis:
-    image: bitnami/redis:7.2
+    image: docker.io/bitnami/redis:7.2
     environment:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
 
   # --- PHP
   php:
-    container_name: linkace-php
     build:
       context: .
       dockerfile: ./resources/docker/dockerfiles/development.Dockerfile

--- a/resources/docker/dockerfiles/development.Dockerfile
+++ b/resources/docker/dockerfiles/development.Dockerfile
@@ -1,7 +1,7 @@
 # DOCKERFILE DEVELOPMENT
 # Installs MySQL Client for database exports, xDebug with PCov and Composer
 
-FROM php:8.1.10-fpm
+FROM docker.io/library/php:8.1.10-fpm
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \

--- a/resources/docker/dockerfiles/release-base.Dockerfile
+++ b/resources/docker/dockerfiles/release-base.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-alpine
+FROM docker.io/library/php:8.3-fpm-alpine
 
 # Install package and PHP dependencies
 RUN apk add --no-cache mariadb-client postgresql postgresql-dev sqlite zip libzip-dev; \

--- a/resources/docker/dockerfiles/release-multiplatform-simple.Dockerfile
+++ b/resources/docker/dockerfiles/release-multiplatform-simple.Dockerfile
@@ -1,5 +1,5 @@
 # DOCKERFILE RELEASE
-FROM linkace/linkace:latest
+FROM docker.io/library/linkace/linkace:latest
 
 # Install nginx and supervisor
 RUN apk add --no-cache nginx supervisor

--- a/resources/docker/dockerfiles/release-multiplatform.Dockerfile
+++ b/resources/docker/dockerfiles/release-multiplatform.Dockerfile
@@ -2,7 +2,7 @@
 
 # ================================
 # PHP Dependency Setup
-FROM linkace/base-image:php-8.3-alpine AS builder
+FROM docker.io/library/linkace/base-image:php-8.3-alpine AS builder
 WORKDIR /app
 
 # Pull composer and install required packages


### PR DESCRIPTION
This commit:

- Specifies which registries it is intending to pull from in the Dockerfiles such that Podman can resolve the dependencies
- Sets a name for the PHP container, such that the commands work when using `exec -it linkace-php`
- Mentions in `CONTRIBUTING.md` that Podman works also
- Updates the PHP version in `CONTRIBUTING.md` as I proposed just now in https://github.com/Kovah/LinkAce/discussions/746#discussioncomment-9101259, since we're touching that line anyway
  - We shouldn't forget to also update the website docs if you like this change

I've tested it by using `podman system reset` which removes all containers and images and such, and then running the commands from the contributing docs in this commit's state, only replacing the word "docker" with "podman" for each command

If this all works well, eventually I think we can also update the documentation in the website repository to mention that Podman seems to work as a drop-in solution even if Docker remains the reference so long as that's what you're developing with. The vibe I get from Podman is that it's less commercial or more in the open source spirit than Docker, which might appeal to those self-hosting LinkAce, besides minor technical/architectural differences where someone might prefer one over the other