### PR TITLE
Reduce release image size

### DIFF
--- a/docker-compose.production-simple.yml
+++ b/docker-compose.production-simple.yml
@@ -17,7 +17,7 @@ services:
 
   # --- LinkAce Image with PHP and nginx
   app:
-    image: docker.io/library/linkace/linkace:simple
+    image: docker.io/linkace/linkace:simple
     restart: unless-stopped
     depends_on:
       - db

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -17,7 +17,7 @@ services:
 
   # --- LinkAce Image with PHP
   app:
-    image: docker.io/library/linkace/linkace:latest
+    image: docker.io/linkace/linkace:latest
     restart: unless-stopped
     depends_on:
       - db

--- a/resources/docker/dockerfiles/release-base.Dockerfile
+++ b/resources/docker/dockerfiles/release-base.Dockerfile
@@ -5,4 +5,6 @@ RUN apk add --no-cache mariadb-client postgresql postgresql-dev sqlite zip libzi
 	docker-php-ext-configure zip; \
 	docker-php-ext-install bcmath pdo_mysql pdo_pgsql zip ftp; \
 	mkdir /ssl-certs; \
-  docker-php-source delete
+	docker-php-source delete; \
+	rm -f /usr/src/php.tar.xz /usr/src/php.tar.xz.asc; \
+	apk del --no-cache postgresql-dev libzip-dev

--- a/resources/docker/dockerfiles/release-base.Dockerfile
+++ b/resources/docker/dockerfiles/release-base.Dockerfile
@@ -1,10 +1,10 @@
 FROM docker.io/library/php:8.3-fpm-alpine
 
 # Install package and PHP dependencies
-RUN apk add --no-cache mariadb-client postgresql postgresql-dev sqlite zip libzip-dev; \
+RUN apk add --no-cache mariadb-client postgresql-client postgresql-dev sqlite zip libzip-dev; \
 	docker-php-ext-configure zip; \
 	docker-php-ext-install bcmath pdo_mysql pdo_pgsql zip ftp; \
 	mkdir /ssl-certs; \
 	docker-php-source delete; \
 	rm -f /usr/src/php.tar.xz /usr/src/php.tar.xz.asc; \
-	apk del --no-cache postgresql-dev libzip-dev
+	apk del --no-cache postgresql-dev


### PR DESCRIPTION
Dev packages are not needed after the initial build. 
This results in a significant reduction in image size.
current release-base size: `739.5 MB`
after this change: `288MB`