### PR TITLE
Use favicon as default link icon if present

### DIFF
--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -270,7 +270,10 @@ class Link extends Model
             return "<!-- Icon icon.$icon could not be found! -->";
         }
 
-        if ($this->hasFavicon()) $icon = 'favicon';
+        if ($this->hasFavicon()) {
+            $icon = 'favicon';
+        }
+        
         return view('models.links.partials.link-icon', [
             'icon' => 'icon.' . $icon,
             'class' => $additionalClasses . ' fw',

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Venturecraft\Revisionable\Revision;
 use Venturecraft\Revisionable\RevisionableTrait;
@@ -268,12 +270,28 @@ class Link extends Model
             return "<!-- Icon icon.$icon could not be found! -->";
         }
 
-        return view('models.links.partials.link-icon', [
+		if ($this->hasFavicon()) $icon = 'favicon';
+		return view('models.links.partials.link-icon', [
             'icon' => 'icon.' . $icon,
             'class' => $additionalClasses . ' fw',
-            'title' => $title,
+			'title' => $title,
+			'faviconUrl' => $this->url . 'favicon.ico'
         ]);
+	}
+
+	public function hasFavicon()
+    {
+		$faviconUrl = $this->url . 'favicon.ico';
+		try {
+			$response = Http::head(($faviconUrl));
+			return $response->successful();
+		} catch (\Exception $e) {
+			Log::error('Check for favicon failed: ' . $e->getMessage());
+			return false;
+		}
+
     }
+
 
     /**
      * Output a relative time inside a span with real time information

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -289,7 +289,6 @@ class Link extends Model
 			Log::error('Check for favicon failed: ' . $e->getMessage());
 			return false;
 		}
-
     }
 
     /**

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -292,7 +292,6 @@ class Link extends Model
 
     }
 
-
     /**
      * Output a relative time inside a span with real time information
      *

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -270,25 +270,25 @@ class Link extends Model
             return "<!-- Icon icon.$icon could not be found! -->";
         }
 
-		if ($this->hasFavicon()) $icon = 'favicon';
-		return view('models.links.partials.link-icon', [
+        if ($this->hasFavicon()) $icon = 'favicon';
+        return view('models.links.partials.link-icon', [
             'icon' => 'icon.' . $icon,
             'class' => $additionalClasses . ' fw',
-			'title' => $title,
-			'faviconUrl' => $this->url . 'favicon.ico'
+            'title' => $title,
+            'faviconUrl' => $this->url . 'favicon.ico'
         ]);
-	}
+    }
 
-	public function hasFavicon()
+    public function hasFavicon()
     {
-		$faviconUrl = $this->url . 'favicon.ico';
-		try {
-			$response = Http::head(($faviconUrl));
-			return $response->successful();
-		} catch (\Exception $e) {
-			Log::error('Check for favicon failed: ' . $e->getMessage());
-			return false;
-		}
+        $faviconUrl = $this->url . 'favicon.ico';
+        try {
+            $response = Http::head(($faviconUrl));
+            return $response->successful();
+        } catch (\Exception $e) {
+            Log::error('Check for favicon failed: ' . $e->getMessage());
+            return false;
+        }
     }
 
     /**

--- a/resources/views/components/icon/favicon.blade.php
+++ b/resources/views/components/icon/favicon.blade.php
@@ -1,0 +1,1 @@
+<img src="{{ $attributes['faviconUrl'] }}" class="" height="20px">

--- a/resources/views/models/links/partials/link-icon.blade.php
+++ b/resources/views/models/links/partials/link-icon.blade.php
@@ -1,2 +1,2 @@
-<x-dynamic-component :component="$icon" class="{{ $class }}" title="{{ $title }}"/>
+<x-dynamic-component :component="$icon" :faviconUrl="$faviconUrl" class="{{ $class }}" title="{{ $title }}"/>
 <span class="visually-hidden">{{ $title }}</span>


### PR DESCRIPTION
This update adds functionality to check if a link has a favicon. If a favicon is present, it will be used as the link icon. If not, the default link icon will be used.
This attempts to fix issue [302](https://github.com/Kovah/LinkAce/issues/302)