### PR TITLE
Add Content-Type and Content-Length header validation middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,6 +44,8 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:60,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\ContentTypeHeaderValidationMiddleware::class,
+            \App\Http\Middleware\ContentLengthHeaderValidationMiddleware::class,
         ],
     ];
 

--- a/app/Http/Middleware/ContentLengthHeaderValidationMiddleware.php
+++ b/app/Http/Middleware/ContentLengthHeaderValidationMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ContentLengthHeaderValidationMiddleware
+{
+    /**
+     * Handle an incoming request.
+     * This middleware ensures that the Content-Length header is set,
+     * otherwise it will return a 411 Length Required response.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if ($request->method() === "POST" && $request->header('Content-Length') === null) {
+            return response()->json([
+                'error' => 'Content-Length header is required.'
+            ], 411);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
+++ b/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+
+class ContentTypeHeaderValidationMiddleware
+{
+    /**
+     * Handle an incoming request.
+     * This middleware ensures that the Content-Type header is set to
+     * application/json, otherwise it will return a 415 Unsupported
+     * Media Type response.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if ($request->method() === "POST" && $request->header('Content-Type') !== 'application/json') {
+            return response()->json([
+                'error' => 'Invalid Content-Type'
+            ], 415);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
+++ b/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
@@ -4,8 +4,6 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
-
 
 class ContentTypeHeaderValidationMiddleware
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,9 @@
     <testsuite name="Helper">
       <directory suffix="Test.php">./tests/Helper</directory>
     </testsuite>
+    <testsuite name="Middleware">
+      <directory suffix="Test.php">./tests/Middleware</directory>
+    </testsuite>
     <testsuite name="Models">
       <directory suffix="Test.php">./tests/Models</directory>
     </testsuite>

--- a/tests/Middleware/ContentLengthHeaderValidationMiddlewareTest.php
+++ b/tests/Middleware/ContentLengthHeaderValidationMiddlewareTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Middleware;
+
+use App\Http\Middleware\ContentLengthHeaderValidationMiddleware;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ContentLengthHeaderValidationMiddlewareTest extends TestCase
+{
+    public function testMissingContentTypeHeader(): void {
+        $request = Request::create('/api/v1/links', 'POST');
+
+        $middleware = new ContentLengthHeaderValidationMiddleware();
+
+        $response = $middleware->handle($request, function () {});
+
+        $this->assertEquals(411, $response->getStatusCode());
+    }
+
+}

--- a/tests/Middleware/ContentLengthHeaderValidationMiddlewareTest.php
+++ b/tests/Middleware/ContentLengthHeaderValidationMiddlewareTest.php
@@ -8,14 +8,15 @@ use Tests\TestCase;
 
 class ContentLengthHeaderValidationMiddlewareTest extends TestCase
 {
-    public function testMissingContentTypeHeader(): void {
+    public function testMissingContentTypeHeader(): void
+    {
         $request = Request::create('/api/v1/links', 'POST');
 
         $middleware = new ContentLengthHeaderValidationMiddleware();
 
-        $response = $middleware->handle($request, function () {});
+        $response = $middleware->handle($request, function () {
+        });
 
         $this->assertEquals(411, $response->getStatusCode());
     }
-
 }

--- a/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
+++ b/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
@@ -8,15 +8,15 @@ use Tests\TestCase;
 
 class ContentTypeHeaderValidationMiddlewareTest extends TestCase
 {
-    public function testMissingContentTypeHeader(): void {
+    public function testMissingContentTypeHeader(): void
+    {
         $request = Request::create('/api/v1/links', 'POST');
-
 
         $middleware = new ContentTypeHeaderValidationMiddleware();
 
-        $response = $middleware->handle($request, function () {});
+        $response = $middleware->handle($request, function () {
+        });
 
         $this->assertEquals(415, $response->getStatusCode());
     }
-
 }

--- a/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
+++ b/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Middleware;
+
+use App\Http\Middleware\ContentTypeHeaderValidationMiddleware;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ContentTypeHeaderValidationMiddlewareTest extends TestCase
+{
+    public function testMissingContentTypeHeader(): void {
+        $request = Request::create('/api/v1/links', 'POST');
+
+
+        $middleware = new ContentTypeHeaderValidationMiddleware();
+
+        $response = $middleware->handle($request, function () {});
+
+        $this->assertEquals(415, $response->getStatusCode());
+    }
+
+}


### PR DESCRIPTION
* If Content-Type is not set to 'application/json' for API POST requests, return a 415 Unsupported Media Type; 
* If Content-Length is not set for API POST requests, return a 411 Length Required.

Fixes #885 

---

This also adds a couple of tests to test the header validation middleware. However, I'm not sure how to, or if we can, test a "good" request to verify a 200 OK.