### PR TITLE
Add Content-Type header validation middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,7 @@ class Kernel extends HttpKernel
         'api' => [
             // Throttling is configured in routes/api.php
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\ContentTypeHeaderValidationMiddleware::class,
         ],
     ];
 

--- a/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
+++ b/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ContentTypeHeaderValidationMiddleware
+{
+    /**
+     * Handle an incoming request.
+     * This middleware ensures that the Content-Type header is set to
+     * application/json, otherwise it will return a 415 Unsupported
+     * Media Type response.
+     *
+     * @param Request $request
+     * @param Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if ($request->method() === "POST" && $request->header('Content-Type') !== 'application/json') {
+            return response()->json([
+                'error' => 'Invalid Content-Type'
+            ], 415);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
+++ b/app/Http/Middleware/ContentTypeHeaderValidationMiddleware.php
@@ -19,7 +19,8 @@ class ContentTypeHeaderValidationMiddleware
      */
     public function handle(Request $request, Closure $next): mixed
     {
-        if ($request->method() === "POST" && $request->header('Content-Type') !== 'application/json') {
+        $checkMethods = ['POST', 'PATCH'];
+        if (in_array($request->method(), $checkMethods) && $request->header('Content-Type') !== 'application/json') {
             return response()->json([
                 'error' => 'Invalid Content-Type'
             ], 415);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,9 @@
     <testsuite name="Helper">
       <directory suffix="Test.php">./tests/Helper</directory>
     </testsuite>
+    <testsuite name="Middleware">
+      <directory suffix="Test.php">./tests/Middleware</directory>
+    </testsuite>
     <testsuite name="Migrations">
       <directory suffix="Test.php">./tests/Migrations</directory>
     </testsuite>

--- a/tests/Controller/API/LinkApiTest.php
+++ b/tests/Controller/API/LinkApiTest.php
@@ -152,6 +152,27 @@ class LinkApiTest extends ApiTestCase
             ]);
     }
 
+    public function test_create_invalid_content_type_request(): void
+    {
+        $list = LinkList::factory()->create(['name' => 'Test List 1']);
+        $tag = Tag::factory()->create(['name' => 'a test 1']);
+        $tag2 = Tag::factory()->create(['name' => 'tag #2']);
+
+        $this->postJsonAuthorized('api/v2/links', [
+            'url' => 'https://example.com',
+            'title' => 'Search the Web',
+            'description' => 'There could be a description here',
+            'lists' => [$list->id],
+            'tags' => [$tag->id, $tag2->id],
+            'visibility' => 1,
+            'check_disabled' => false,
+        ], ['Content-Type' => 'application/xml'])
+            ->assertUnsupportedMediaType()
+            ->assertJson([
+                'error' => "Invalid Content-Type"
+            ]);
+    }
+
     public function test_create_request_with_list(): void
     {
         $list = LinkList::factory()->create(['name' => 'Test List 1']);
@@ -446,6 +467,25 @@ class LinkApiTest extends ApiTestCase
             'is_private' => false,
             'check_disabled' => false,
         ])->assertForbidden();
+    }
+
+    public function test_update_invalid_content_type_request(): void
+    {
+        $list = LinkList::factory()->create();
+        $this->createTestLinks();
+
+        $this->patchJsonAuthorized('api/v2/links/1', [
+            'url' => 'https://new-public-link.com',
+            'title' => 'Custom Title',
+            'description' => 'Custom Description',
+            'lists' => [$list->id],
+            'is_private' => false,
+            'check_disabled' => false,
+        ], ['Content-Type' => 'application/xml'])
+            ->assertUnsupportedMediaType()
+            ->assertJson([
+                'error' => 'Invalid Content-Type'
+            ]);
     }
 
     public function test_invalid_update_request(): void

--- a/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
+++ b/tests/Middleware/ContentTypeHeaderValidationMiddlewareTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Middleware;
+
+use App\Http\Middleware\ContentTypeHeaderValidationMiddleware;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ContentTypeHeaderValidationMiddlewareTest extends TestCase
+{
+    public function testMissingContentTypeHeader(): void
+    {
+        $request = Request::create('/api/v1/links', 'POST');
+
+        $middleware = new ContentTypeHeaderValidationMiddleware();
+
+        $response = $middleware->handle($request, function () {
+        });
+
+        $this->assertEquals(415, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
* If Content-Type is not set to 'application/json' for API POST requests, return a 415 Unsupported Media Type.

Replaces #887
Fixes #885 

Something seems to have changed with the request behavior, I'm not sure if that's a due to an updated dependency, but Content-Length is no longer null for `$request`, and since most tools automatically calculate it, maybe we don't need to explicitly validate for it. 