### PR TITLE
Fix typo when adding Bluesky sharing method.

### DIFF
--- a/database/settings/2025_02_15_092008_add_bluesky_share_method.php
+++ b/database/settings/2025_02_15_092008_add_bluesky_share_method.php
@@ -9,7 +9,7 @@ return new class extends SettingsMigration {
 
         foreach (DB::table('users')->pluck('id') as $userId) {
             $id = 'user-' . $userId;
-            $this->migrator->add($id . '.shareAdd_bluesky', false);
+            $this->migrator->add($id . '.share_bluesky', false);
         }
     }
 };


### PR DESCRIPTION
Changes `shareAdd_bluesky` to `share_bluesky` in the migration file to prevent a fatal error.

Fixes #913