### PR TITLE
Enable SSO logins through the bookmarklet.

### DIFF
--- a/resources/views/app/bookmarklet/login.blade.php
+++ b/resources/views/app/bookmarklet/login.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.bookmarklet')
 
 @section('content')
-    @include('auth.login-form')
+    @if(config('auth.sso.regular_login_disabled') !== true)
+        @include('auth.login-form')
+    @endif
+    @if(config('auth.sso.enabled') === true)
+        @include('auth.oauth')
+    @endif
 @endsection


### PR DESCRIPTION
When you use the bookmarklet runs for a not logged in user, it redirects to a login page. This login page currently only accepts username/password.
This PR updated the `login.blade.php` file to include the SSO login buttons (if enabled), and disable teh user/password form if regular login has been disabled.