### PR TITLE
fix: allow users to search shared links

### DIFF
--- a/app/Http/Controllers/Traits/SearchesLinks.php
+++ b/app/Http/Controllers/Traits/SearchesLinks.php
@@ -38,7 +38,7 @@ trait SearchesLinks
     protected function buildDatabaseQuery(SearchRequest $request): Builder
     {
         // Start building the search
-        $search = Link::byUser($request->user()->id)->with(['tags']);
+        $search = Link::visibleForUser()->with(['tags']);
 
         // Search for the URL
         if ($this->searchQuery = $request->input('query')) {


### PR DESCRIPTION

## What the problem was
I noticed that other users couldn't search for links created by my admin account, even though those links had public visibility set.
* Users were still able to view the links through the Links, Lists, and Tags tab.
* The issue was specific to the search functionality.

## The solution
I updated the query in `app/Http/Controllers/Traits/SearchesLinks.php` to use the  `visibleForUser` scope instead of filtering by the current user ID. This ensures that users can search for any links they should have access to.