### PR TITLE
feature: guest tags filter

### DIFF
--- a/app/Http/Controllers/Guest/TagController.php
+++ b/app/Http/Controllers/Guest/TagController.php
@@ -28,8 +28,13 @@ class TagController extends Controller
 
         $tags = Tag::publicOnly()
             ->withCount(['links' => fn($query) => $query->publicOnly()])
-            ->orderBy($this->orderBy, $this->orderDir)
-            ->paginate(getPaginationLimit());
+            ->orderBy($this->orderBy, $this->orderDir);
+
+        if ($request->input('filter')) {
+            $tags = $tags->where('name', 'like', '%' . $request->input('filter') . '%');
+        }
+
+        $tags = $tags->paginate(getPaginationLimit());
 
         return view('guest.tags.index', [
             'pageTitle' => trans('tag.tags'),

--- a/resources/views/guest/tags/index.blade.php
+++ b/resources/views/guest/tags/index.blade.php
@@ -10,10 +10,28 @@
         <h3 class="mb-0 me-3">
             @lang('tag.tags')
         </h3>
-        <a href="{{ route('guest.tags.feed') }}" class="ms-auto btn btn-sm btn-outline-secondary">
-            <x-icon.feed/>
-            <span class="visually-hidden">@lang('linkace.feed')</span>
-        </a>
+        <div class="mb-0 ms-auto">
+            <div class="d-flex flex-column flex-sm-row gap-3">
+                <form action="{{ route('guest.tags.index') }}" method="GET">
+                    <label for="filter" class="visually-hidden">@lang('tag.filter_tags')</label>
+                    <div class="input-group input-group-sm mb-1 mb-sm-0 me-sm-2">
+                        <input type="text" name="filter" id="filter" minlength="1"
+                            class="form-control" placeholder="@lang('tag.filter_tags')"
+                            value="{{ request()->input('filter') }}"/>
+                        <a href="{{ route('guest.tags.index') }}" class="btn btn-sm btn-outline-primary">
+                            <x-icon.ban/>
+                        </a>
+                        <button class="btn btn-primary" type="submit" title="@lang('list.filter_lists')">
+                            <x-icon.search/>
+                        </button>
+                    </div>
+                </form>
+                <a href="{{ route('guest.tags.feed') }}" class="ms-auto btn btn-sm btn-outline-secondary">
+                    <x-icon.feed/>
+                    <span class="visually-hidden">@lang('linkace.feed')</span>
+                </a>
+            </div>
+        </div>
     </header>
 
     <div class="tags-listing card my-3 mb-3">

--- a/tests/Controller/Guest/TagControllerTest.php
+++ b/tests/Controller/Guest/TagControllerTest.php
@@ -67,4 +67,22 @@ class TagControllerTest extends TestCase
         $this->get('guest/tags/1')->assertNotFound();
         $this->get('guest/tags/myTag')->assertNotFound();
     }
+
+    public function test_tag_search(): void
+    {
+        User::factory()->create();
+        Tag::factory()->create([
+            'name' => 'testTag1',
+            'visibility' => 1,
+        ]);
+        Tag::factory()->create([
+            'name' => 'testTag2',
+            'visibility' => 1,
+        ]);
+        $this->get('guest/tags?filter=testTag1')->assertSee('testTag1')
+            ->assertDontSee('testTag2');
+
+        $this->get('guest/tags?filter=testTag2')->assertSee('testTag2')
+            ->assertDontSee('testTag1');
+    }
 }


### PR DESCRIPTION
#1024 

Changes:
- feat(tags): add filter functionality to tag listing page on guest
- test(guest/tag): add tag search test cases

How to reproduce
- enable guest access
- logout.
- go to tag list.

Expected behavior
- the tag filter feature is available to guests.

<img width="1343" height="420" alt="image" src="https://github.com/user-attachments/assets/8394cfea-b297-4b5a-bb08-9150aa4d2010" />