### PR TITLE
fix(sso): read preferred_username claim during SSO login

### DIFF
--- a/app/Http/Controllers/SocialiteController.php
+++ b/app/Http/Controllers/SocialiteController.php
@@ -33,7 +33,7 @@ class SocialiteController extends Controller
             }
 
             $user->update([
-                'name' => $authUser->getNickname() ?: Str::studly($authUser->getName()),
+                'name' => $authUser->getNickname() ?: (($authUser->getRaw() ?? [])['preferred_username'] ?? Str::studly($authUser->getName())),
                 'sso_id' => $authUser->id,
                 'sso_provider' => $provider,
                 'sso_token' => $authUser->token ?? null,
@@ -58,7 +58,7 @@ class SocialiteController extends Controller
                 'sso_id' => $authUser->getId(),
                 'sso_provider' => $provider,
             ], [
-                'name' => $authUser->getNickname() ?: Str::studly($authUser->getName()),
+                'name' => $authUser->getNickname() ?: (($authUser->getRaw() ?? [])['preferred_username'] ?? Str::studly($authUser->getName())),
                 'email' => $authUser->getEmail(),
                 'sso_id' => $authUser->getId(),
                 'sso_provider' => $provider,


### PR DESCRIPTION
Prevents LinkAce from forcing a studly-cased full name on users when their identity provider supplies their actual username within the `preferred_username` OIDC claim.

For example, [PocketID](https://pocket-id.org/) doesn't have `nickname` claim by default, but it does have a `preferred_username` claim. PR works fine with other providers who also don't have a `nickname` claim, and doesn't cause any problem with providers who do.