### PR TITLE
feat(sso): auto-redirect to SSO provider when regular login is disabled

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -33,7 +33,17 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
-        Fortify::loginView(fn() => view('auth.login', ['pageTitle' => trans('linkace.login')]));
+        Fortify::loginView(function () {
+            if (config('auth.sso.enabled') && config('auth.sso.regular_login_disabled') && config('auth.sso.auto_redirect')) {
+                foreach (config('auth.sso.providers', []) as $provider) {
+                    if (config('services.' . $provider . '.enabled')) {
+                        return redirect()->route('auth.sso.redirect', ['provider' => $provider]);
+                    }
+                }
+            }
+
+            return view('auth.login', ['pageTitle' => trans('linkace.login')]);
+        });
 
         Fortify::requestPasswordResetLinkView(fn() => view('auth.passwords.email', ['pageTitle' => trans('linkace.login')]));
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -28,6 +28,7 @@ return [
         'enabled' => env('SSO_ENABLED', false),
         'registration_enabled' => env('SSO_REGISTRATION_ENABLED', true),
         'regular_login_disabled' => env('REGULAR_LOGIN_DISABLED', false),
+        'auto_redirect' => env('SSO_AUTO_REDIRECT', false),
         'providers' => [
             'auth0',
             'authentik',

--- a/tests/Controller/Auth/LoginControllerTest.php
+++ b/tests/Controller/Auth/LoginControllerTest.php
@@ -60,4 +60,17 @@ class LoginControllerTest extends TestCase
         $confirmView = $this->actingAs($user)->get('user/confirm-password');
         $confirmView->assertSee('Confirmation required');
     }
+
+    public function test_sso_auto_redirect(): void
+    {
+        config(['auth.sso.enabled' => true]);
+        config(['auth.sso.regular_login_disabled' => true]);
+        config(['auth.sso.auto_redirect' => true]);
+        config(['auth.sso.providers' => ['authentik']]);
+        config(['services.authentik.enabled' => true]);
+
+        $response = $this->get('login');
+
+        $response->assertRedirect(route('auth.sso.redirect', ['provider' => 'authentik']));
+    }
 }


### PR DESCRIPTION
Added a new `SSO_AUTO_REDIRECT` configuration option. When this is set to true and regular login is disabled, users are automatically redirected to the configured SSO provider's authorization flow, bypassing the intermediate login screen.

Also discussed in #1060

After the merge, I can prepare another PR in the appropriate repo to apply changes to the documentation.